### PR TITLE
feat: add configurable debounceWindowSeconds and resyncIntervalMinutes

### DIFF
--- a/templates/capabilityscanconfig.yaml
+++ b/templates/capabilityscanconfig.yaml
@@ -12,4 +12,7 @@ spec:
     authSecretRef:
       name: dot-ai-secrets
       key: auth-token
+  {{- with .Values.capabilityScan.debounceWindowSeconds }}
+  debounceWindowSeconds: {{ . }}
+  {{- end }}
 {{- end }}

--- a/templates/resourcesyncconfig.yaml
+++ b/templates/resourcesyncconfig.yaml
@@ -11,4 +11,10 @@ spec:
   mcpAuthSecretRef:
     name: dot-ai-secrets
     key: auth-token
+  {{- with .Values.resourceSync.debounceWindowSeconds }}
+  debounceWindowSeconds: {{ . }}
+  {{- end }}
+  {{- with .Values.resourceSync.resyncIntervalMinutes }}
+  resyncIntervalMinutes: {{ . }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -51,8 +51,11 @@ dot-ai-ui:
 # Docs: https://devopstoolkit.ai/docs/controller/resource-sync-guide
 resourceSync:
   enabled: true
+  # debounceWindowSeconds: 30    # Seconds to wait before syncing after a change (default: 10, max: 300)
+  # resyncIntervalMinutes: 120   # Minutes between full resyncs (default: 60, max: 1440)
 
 # CapabilityScanConfig - enables cluster capability discovery
 # Docs: https://devopstoolkit.ai/docs/controller/capability-scan-guide
 capabilityScan:
   enabled: true
+  # debounceWindowSeconds: 30    # Seconds to wait before scanning after a change (default: 10, max: 300)


### PR DESCRIPTION
## Summary
- Expose `debounceWindowSeconds` for both ResourceSyncConfig and CapabilityScanConfig
- Expose `resyncIntervalMinutes` for ResourceSyncConfig only (not supported by CapabilityScanConfig CRD)
- Values are optional and commented out by default, preserving backward compatibility
- Fixed documentation to reflect actual CRD defaults (10s debounce, 60m resync)

## Changes
- `templates/resourcesyncconfig.yaml`: Added debounceWindowSeconds and resyncIntervalMinutes
- `templates/capabilityscanconfig.yaml`: Added debounceWindowSeconds only
- `values.yaml`: Added commented examples with correct defaults and max values

## Test plan
- [ ] `helm template` renders valid YAML
- [ ] Apply to test cluster with custom values
- [ ] Verify CRD validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `debounceWindowSeconds` configuration parameter for capability scan operations
  * Added optional `debounceWindowSeconds` and `resyncIntervalMinutes` configuration parameters for resource synchronization

* **Documentation**
  * Added commented configuration examples for new timing parameters in settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->