### PR TITLE
fix(chart): add condition field to optional dependencies

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,15 +2,18 @@ apiVersion: v2
 name: dot-ai-stack
 description: Complete dot-ai stack - MCP server, controller, and UI
 type: application
-version: 0.38.0
+version: 0.38.1
 appVersion: "0.38.0"
 dependencies:
   - name: dot-ai
     version: "1.0.3"
     repository: "oci://ghcr.io/vfarcic/dot-ai/charts"
+    # No condition - dot-ai MCP server is the core component and always required
   - name: dot-ai-controller
     version: "0.44.1"
     repository: "oci://ghcr.io/vfarcic/dot-ai-controller/charts"
+    condition: dot-ai-controller.enabled
   - name: dot-ai-ui
     version: "0.11.0"
     repository: "oci://ghcr.io/vfarcic/dot-ai-ui/charts"
+    condition: dot-ai-ui.enabled

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 # dot-ai-stack umbrella chart values
 # Override sub-chart values by nesting under the chart name
 
-# dot-ai MCP server configuration
+# dot-ai MCP server configuration (core component - always deployed)
 # Docs: https://devopstoolkit.ai/docs/mcp/setup/kubernetes-setup
 dot-ai:
   # Fixed service name so dot-ai-ui can find it at http://dot-ai:3456
@@ -23,6 +23,8 @@ dot-ai:
 # dot-ai-controller configuration
 # Docs: https://devopstoolkit.ai/docs/controller/setup-guide
 dot-ai-controller:
+  # Set to false to disable the controller (e.g., for MCP-only usage)
+  enabled: true
   fullnameOverride: dot-ai-controller
   # Example overrides:
   # resources:
@@ -33,6 +35,8 @@ dot-ai-controller:
 # dot-ai-ui web interface configuration
 # Docs: https://devopstoolkit.ai/docs/ui/setup/kubernetes-setup
 dot-ai-ui:
+  # Set to false to disable the web UI
+  enabled: true
   fullnameOverride: dot-ai-ui
   # Example overrides:
   # dotAi:


### PR DESCRIPTION
## Summary

Add `condition` field to optional subchart dependencies so users can properly disable components.

## Problem

When setting `dot-ai-controller.enabled: false`, the controller resources (ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment) were still rendered because the dependency lacked a `condition` field.

This caused issues with Flux drift detection reporting removed resources when users disabled components that were previously deployed.

### Reproduction Steps

```bash
# With current chart (0.38.0)
helm template test . --set dot-ai-controller.enabled=false | grep controller-manager
# Output: controller resources still present ❌
```

## Solution

- Add `condition: dot-ai-controller.enabled` to controller dependency
- Add `condition: dot-ai-ui.enabled` to UI dependency  
- Add default `enabled: true` values for controller and UI in values.yaml
- Bump chart version to 0.38.1

Note: `dot-ai` MCP server has no condition as it's the core component and should always be deployed when using this stack.

## Testing

```bash
# With this fix
helm dependency update
helm template test . --set dot-ai-controller.enabled=false | grep controller
# Output: (empty) ✅

helm template test . --set dot-ai-ui.enabled=false | grep dot-ai-ui
# Output: (empty) ✅
```

## Checklist

- [x] Chart version bumped (0.38.0 → 0.38.1)
- [x] Backward compatible (default `enabled: true`)
- [x] Tested locally with `helm template`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional configuration flags that allow you to independently enable or disable the dot-ai-controller and dot-ai-ui components. This gives you greater control over your deployment, enabling you to deploy only the components you need. Both components are enabled by default to maintain backward compatibility.

* **Chores**
  * Version bump to 0.38.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->